### PR TITLE
OS X Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,5 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
-  - npm install
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run unbuild ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run build ; fi
+  - npm install --ignore-scripts
+  - npm run BigRedButton

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
   - osx
 osx_image: xcode7.3
-sudo: false
+sudo: required
 language: node_js
 node_js:
   - "4.4.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ os:
   - linux
   - osx
 osx_image: xcode7.3
-sudo: required
+sudo: false
 language: node_js
 node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build build.dmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg.sparseimage ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build ../build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach ../build.dmg.sparseimage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
-  - npm run build
+  - npm install
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run unbuild ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run build ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+os:
+  - linux
+  - osx
+osx_image: xcode7.3
+sudo: required
+language: node_js
+node_js:
+  - "4.4.6"
+  - "6.2.2"
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info binutils; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info gnu-sed; fi
+script:
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build -srcfolder . build.dmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach -readwrite build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -volname build -srcfolder . build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo hdiutil attach -readwrite build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ language: node_js
 node_js:
   - "4.4.6"
   - "6.2.2"
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build -srcfolder . build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -volname build -srcfolder . build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r . /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
-  - npm install --ignore-scripts
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "6.2.2"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -volname build -srcfolder . build.dmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo hdiutil attach -readwrite build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 os:
-  - linux
   - osx
 osx_image: xcode7.3
 sudo: required
-dist: trusty
 language: node_js
 node_js:
-  - "4.4.6"
   - "6.2.2"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build ../build.dmg ; fi
@@ -18,4 +15,3 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
   - npm install --ignore-scripts
-  - npm run BigRedButton

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg.sparseimage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r . /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg.sparseimage ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r . /Volumes/build ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,19 @@ os:
   - osx
 osx_image: xcode7.3
 sudo: required
+dist: trusty
 language: node_js
 node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build ../build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach ../build.dmg.sparseimage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR/* /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install g++-4.8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
   - npm install --ignore-scripts
-  - travis_wait 70 npm run BigRedButton
+  - npm run BigRedButton

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "6.2.2"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build build.dmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg.sparseimage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r . /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ node_js:
   - "6.2.2"
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info binutils; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info gnu-sed; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
-  - npm install
+  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "6.2.2"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build -srcfolder . build.dmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach -readwrite build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build -srcfolder . build.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -fs 'Case-sensitive Journaled HFS+' -size 5g -volname build -srcfolder . build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# While Travis Support has been implemented for OSX, it does not fully build
+# due to the build time limit and the vast ammount of warnings generated
+
 os:
   - osx
 osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,17 @@ node_js:
   - "4.4.6"
   - "6.2.2"
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build ../build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach ../build.dmg.sparseimage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR/* /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install g++-4.8 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnu-sed --with-default-names ; fi
 script:
   - npm install --ignore-scripts
-  - npm run BigRedButton
+  - travis_wait 70 npm run BigRedButton

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil create -type SPARSE -fs 'Case-sensitive Journaled HFS+' -size 10g -volname build ../build.dmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then hdiutil attach ../build.dmg.sparseimage ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR /Volumes/build ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp -r $TRAVIS_BUILD_DIR/* /Volumes/build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /Volumes/build ; fi
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi

--- a/install-dependencies
+++ b/install-dependencies
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Clean object dir and return the input error
+function err(){
+  rm -rf $DEPS_GLIBC
+  exit $1
+}
+
+#
+# Applies OSX "dependencies" needed to compile the linux kernel
+#
+
+if [[ $(uname -s) = "Darwin" ]]; then
+  command -v port >/dev/null ||
+  (
+    echo "MacPorts is not installed" &&
+    echo "Please visit https://www.macports.org/ for more information" &&
+    exit 40
+  )
+
+  port -q install gsed || err $?
+
+  ln -s /opt/local/bin/gsed /usr/local/bin/sed
+
+  GLIBC_VERSION=2.23
+  GLIBC_TAR=glibc-$GLIBC_VERSION.tar.gz
+  GLIBC_URL=http://ftpmirror.gnu.org/glibc/$GLIBC_TAR
+
+  INCLUDE=/usr/local/include
+  BASE=`pwd`
+  DEPS=$BASE/deps
+  DEPS_GLIBC=$DEPS/glibc-$GLIBC_VERSION
+
+  rm -rf $DEPS_GLIBC
+
+  cd $DEPS
+  curl -LO $GLIBC_URL || err $?
+  tar xfz $GLIBC_TAR || err $?
+
+  rm -r $GLIBC_TAR
+  cd $DEPS_GLIBC
+
+  mkdir -p $INCLUDE/elf || err $?
+  mkdir -p $INCLUDE/bits || err $?
+  mkdir -p $INCLUDE/string || err $?
+  mkdir -p $INCLUDE/gnu || err $?
+
+  cp include/elf.h $INCLUDE || err $?
+  cp elf/elf.h $INCLUDE/elf || err $?
+  cp sysdeps/generic/dl-dtprocnum.h $INCLUDE || err $?
+
+  cp include/features.h $INCLUDE || err $?
+  cp include/gnu/stubs.h $INCLUDE/gnu || err $?
+
+  cp include/stdc-predef.h $INCLUDE || err $?
+
+  cp include/byteswap.h $INCLUDE || err $?
+  cp string/byteswap.h $INCLUDE/string || err $?
+  cp sysdeps/x86/bits/byteswap.h $INCLUDE/bits || err $?
+  cp sunrpc/rpc/types.h $INCLUDE/bits || err $?
+  cp sysdeps/x86/bits/byteswap-16.h $INCLUDE/bits || err $?
+  cp sysdeps/x86/bits/wordsize.h $INCLUDE/bits || err $?
+
+  cp include/endian.h $INCLUDE || err $?
+  cp string/endian.h $INCLUDE/string || err $?
+  cp sysdeps/x86/bits/endian.h $INCLUDE/bits || err $?
+
+  rm -rf $DEPS_GLIBC
+
+  echo "done."
+fi

--- a/install-dependencies
+++ b/install-dependencies
@@ -2,12 +2,6 @@
 
 set +h
 
-# Clean object dir and return the input error
-function err(){
-  rm -rf $DEPS_GLIBC
-  exit $1
-}
-
 #
 # Applies OSX "dependencies" needed to compile the linux kernel
 #
@@ -20,9 +14,9 @@ if [[ $(uname -s) = "Darwin" ]]; then
     exit 40
   )
 
-  port -q install gsed || err $?
-  ln -s /opt/local/bin/gsed /usr/local/bin/sed  || err $?
+  port -q install gsed || exit $?
+  ln -s /opt/local/bin/gsed /usr/local/bin/sed  || exit $?
 
-  port -q install binutils || err $?
-  ln -s /opt/local/bin/gstrip /usr/local/bin/strip  || err $?
+  port -q install binutils || exit $?
+  ln -s /opt/local/bin/gstrip /usr/local/bin/strip  || exit $?
 fi

--- a/install-dependencies
+++ b/install-dependencies
@@ -19,53 +19,8 @@ if [[ $(uname -s) = "Darwin" ]]; then
   )
 
   port -q install gsed || err $?
+  ln -s /opt/local/bin/gsed /usr/local/bin/sed  || err $?
 
-  ln -s /opt/local/bin/gsed /usr/local/bin/sed
-
-  GLIBC_VERSION=2.23
-  GLIBC_TAR=glibc-$GLIBC_VERSION.tar.gz
-  GLIBC_URL=http://ftpmirror.gnu.org/glibc/$GLIBC_TAR
-
-  INCLUDE=/usr/local/include
-  BASE=`pwd`
-  DEPS=$BASE/deps
-  DEPS_GLIBC=$DEPS/glibc-$GLIBC_VERSION
-
-  rm -rf $DEPS_GLIBC
-
-  cd $DEPS
-  curl -LO $GLIBC_URL || err $?
-  tar xfz $GLIBC_TAR || err $?
-
-  rm -r $GLIBC_TAR
-  cd $DEPS_GLIBC
-
-  mkdir -p $INCLUDE/elf || err $?
-  mkdir -p $INCLUDE/bits || err $?
-  mkdir -p $INCLUDE/string || err $?
-  mkdir -p $INCLUDE/gnu || err $?
-
-  cp include/elf.h $INCLUDE || err $?
-  cp elf/elf.h $INCLUDE/elf || err $?
-  cp sysdeps/generic/dl-dtprocnum.h $INCLUDE || err $?
-
-  cp include/features.h $INCLUDE || err $?
-  cp include/gnu/stubs.h $INCLUDE/gnu || err $?
-
-  cp include/stdc-predef.h $INCLUDE || err $?
-
-  cp include/byteswap.h $INCLUDE || err $?
-  cp string/byteswap.h $INCLUDE/string || err $?
-  cp sysdeps/x86/bits/byteswap.h $INCLUDE/bits || err $?
-  cp sunrpc/rpc/types.h $INCLUDE/bits || err $?
-  cp sysdeps/x86/bits/byteswap-16.h $INCLUDE/bits || err $?
-  cp sysdeps/x86/bits/wordsize.h $INCLUDE/bits || err $?
-
-  cp include/endian.h $INCLUDE || err $?
-  cp string/endian.h $INCLUDE/string || err $?
-  cp sysdeps/x86/bits/endian.h $INCLUDE/bits || err $?
-
-  rm -rf $DEPS_GLIBC
-
-  echo "done."
+  port -q install binutils || err $?
+  ln -s /opt/local/bin/gstrip /usr/local/bin/strip  || err $?
 fi

--- a/install-dependencies
+++ b/install-dependencies
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set +h
+
 # Clean object dir and return the input error
 function err(){
   rm -rf $DEPS_GLIBC

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "download-manager": "^0.0.20",
     "fs-extra": "^0.30.0",
-    "prebuild-install": "1.0.2"
+    "prebuild-install": "1.0.2",
+    "async": "^2.0.0-rc.6"
   },
   "devDependencies": {
     "prebuild": "^4.2.2"

--- a/patches/linux-4.6.diff
+++ b/patches/linux-4.6.diff
@@ -5,16 +5,14 @@
  endif
  
 +ifeq ($(shell uname), Darwin)
-+HOSTCFLAGS   += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized         \
-+  -Wshift-negative-value -Wextended-offsetof -Wdeprecated-declarations         \
-+  -Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
-+  -Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags        \
-+  -Wc99-extensions
-+HOSTCXXFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized         \
-+  -Wshift-negative-value -Wextended-offsetof -Wdeprecated-declarations         \
-+  -Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
-+  -Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags        \        
-+  -Wc99-extensions
++HOSTCFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized                        \
++		-Wc99-extensions -Wextended-offsetof -Wdeprecated-declarations               \
++		-Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
++		-Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags
++HOSTCXXFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized                      \
++		-Wc99-extensions -Wextended-offsetof -Wdeprecated-declarations               \
++		-Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
++		-Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags
 +endif
 +
  # Decide whether to build built-in, modular, or both.

--- a/patches/linux-4.6.diff
+++ b/patches/linux-4.6.diff
@@ -1,0 +1,22 @@
+--- Makefile
++++ Makefile
+@@ -305,6 +305,19 @@
+ 		-Wno-missing-field-initializers -fno-delete-null-pointer-checks
+ endif
+ 
++ifeq ($(shell uname), Darwin)
++HOSTCFLAGS   += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized         \
++  -Wshift-negative-value -Wextended-offsetof -Wdeprecated-declarations         \
++  -Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
++  -Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags        \
++  -Wc99-extensions
++HOSTCXXFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized         \
++  -Wshift-negative-value -Wextended-offsetof -Wdeprecated-declarations         \
++  -Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
++  -Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags        \        
++  -Wc99-extensions
++endif
++
+ # Decide whether to build built-in, modular, or both.
+ # Normally, just do built-in.
+ 

--- a/patches/linux-4.6.diff
+++ b/patches/linux-4.6.diff
@@ -5,14 +5,8 @@
  endif
  
 +ifeq ($(shell uname), Darwin)
-+HOSTCFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized                        \
-+		-Wc99-extensions -Wextended-offsetof -Wdeprecated-declarations               \
-+		-Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
-+		-Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags
-+HOSTCXXFLAGS += -I../glibc -Wmacro-redefined -Wsometimes-uninitialized                      \
-+		-Wc99-extensions -Wextended-offsetof -Wdeprecated-declarations               \
-+		-Wbitwise-op-parentheses -Wunused-value -Wparentheses -Wtautological-compare \
-+		-Wkeyword-macro -Wformat-security -Wchar-subscripts -Wmismatched-tags
++HOSTCFLAGS += -I../glibc -w
++HOSTCXXFLAGS += -I../glibc -w
 +endif
 +
  # Decide whether to build built-in, modular, or both.

--- a/patches/linux/LICENSE
+++ b/patches/linux/LICENSE
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/patches/linux/linux-4.6.diff
+++ b/patches/linux/linux-4.6.diff
@@ -1,12 +1,12 @@
 --- Makefile
 +++ Makefile
-@@ -305,6 +305,19 @@
+@@ -305,6 +305,11 @@
  		-Wno-missing-field-initializers -fno-delete-null-pointer-checks
  endif
  
 +ifeq ($(shell uname), Darwin)
-+HOSTCFLAGS += -I../glibc -w
-+HOSTCXXFLAGS += -I../glibc -w
++HOSTCFLAGS += -I../glibc
++HOSTCXXFLAGS += -I../glibc
 +endif
 +
  # Decide whether to build built-in, modular, or both.

--- a/scripts/BigRedButton
+++ b/scripts/BigRedButton
@@ -8,7 +8,7 @@ source scripts/adjustEnvVars.sh
 #
 
 PRODUCTS=(bin lib libexec share *-nodeos-linux-musl)
-PREBUILD=prebuilds/linux-$NODE_ARCH.tar.gz
+PREBUILD=prebuilds/$KERNEL_NAME-$NODE_ARCH.tar.gz
 
 
 # Clean products previously to create them

--- a/scripts/adjustEnvVars.sh
+++ b/scripts/adjustEnvVars.sh
@@ -145,7 +145,7 @@ OBJECTS=`pwd`/build/$CPU
 MAKE1="make ${SILENT:=--silent LIBTOOLFLAGS=--silent V=}"
 MAKE="$MAKE1 --jobs=$JOBS"
 
-KERNEL_NAME=$(uname -s)
+KERNEL_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 function rmStep(){
   rm -rf "$@"

--- a/scripts/adjustEnvVars.sh
+++ b/scripts/adjustEnvVars.sh
@@ -4,6 +4,7 @@ RED="\e[31m"
 GRN="\e[32m"
 WHT="\e[37m"
 CLR="\e[0m"
+NWL="\n"
 
 # Platform aliases
 case $PLATFORM in
@@ -147,12 +148,11 @@ MAKE="$MAKE1 --jobs=$JOBS"
 
 function rmStep(){
   rm -rf "$@"
-  rmdir -p --ignore-fail-on-non-empty `dirname "$@"`
 }
 
 # Clean object dir and return the input error
 function err(){
-  echo -e "${RED}Error compiling '${OBJ_DIR}'${CLR}"
+  printf "${RED}Error compiling '${OBJ_DIR}'${CLR}${NWL}"
   rmStep $OBJ_DIR
   exit $1
 }

--- a/scripts/adjustEnvVars.sh
+++ b/scripts/adjustEnvVars.sh
@@ -145,6 +145,7 @@ OBJECTS=`pwd`/build/$CPU
 MAKE1="make ${SILENT:=--silent LIBTOOLFLAGS=--silent V=}"
 MAKE="$MAKE1 --jobs=$JOBS"
 
+KERNEL_NAME=$(uname -s)
 
 function rmStep(){
   rm -rf "$@"

--- a/scripts/build
+++ b/scripts/build
@@ -57,9 +57,9 @@ if [[ ! -d $STEP_DIR ]]; then
     cd $SRC_DIR
 
     # Extract headers
-    $MAKE mrproper > /dev/null                                                      &&
-    $MAKE ARCH=$ARCH headers_check > /dev/null                                      &&
-    $MAKE ARCH=$ARCH INSTALL_HDR_PATH=$OUT_DIR/$TARGET headers_install  > /dev/null || exit 10
+    $MAKE mrproper                                                     &&
+    $MAKE ARCH=$ARCH headers_check                                     &&
+    $MAKE ARCH=$ARCH INSTALL_HDR_PATH=$OUT_DIR/$TARGET headers_install || exit 10
   ) || err $?
 
   printf "${GRN}Successfully extracted Linux headers${CLR}${NWL}"
@@ -92,10 +92,10 @@ if [[ ! -d $STEP_DIR ]]; then
         --disable-multilib              || exit 21
 
     # Compile
-    $MAKE configure-host > /dev/null && $MAKE > /dev/null || exit 22
+    $MAKE configure-host && $MAKE || exit 22
 
     # Install
-    $MAKE install > /dev/null || exit 23
+    $MAKE instal || exit 23
   ) || err $?
 
   printf "${GRN}Successfully compiled binutils${CLR}${NWL}"
@@ -149,10 +149,10 @@ if [[ ! -d $STEP_DIR ]]; then
 #        -mtune=$TUNE                          \
 
     # Compile
-    $MAKE all-gcc all-target-libgcc > /dev/null || exit 33
+    $MAKE all-gcc all-target-libgcc || exit 33
 
     # Install
-    $MAKE install-gcc install-target-libgcc > /dev/null || exit 34
+    $MAKE install-gcc install-target-libgcc || exit 34
   ) || err $?
 
   # Remove object files to allow generation of final version
@@ -191,10 +191,10 @@ if [[ ! -d $STEP_DIR ]]; then
         --disable-static     || exit 41
 
     # Compile
-    CROSS_COMPILE="$TARGET-" $MAKE > /dev/null || exit 42
+    CROSS_COMPILE="$TARGET-" $MAKE || exit 42
 
     # Install
-    DESTDIR=$OUT_DIR/$TARGET $MAKE install > /dev/null || exit 43
+    DESTDIR=$OUT_DIR/$TARGET $MAKE install || exit 43
   ) || err $?
 
   printf "${GRN}Successfully compiled musl${CLR}${NWL}"
@@ -240,10 +240,10 @@ if [[ ! -d $STEP_DIR ]]; then
 #        -mtune=$TUNE                          \
 
     # Compile
-    $MAKE > /dev/null || exit 52
+    $MAKE || exit 52
 
     # Install
-    $MAKE install > /dev/null || exit 53
+    $MAKE install || exit 53
   ) || err $?
 
   printf "${GRN}Successfully compiled GCC final${CLR}${NWL}"

--- a/scripts/build
+++ b/scripts/build
@@ -49,7 +49,7 @@ SRC_DIR=$DEPS/linux
 STEP_DIR=$KERNEL_HEADERS
 
 if [[ ! -d $STEP_DIR ]]; then
-  echo -e "${WHT}Extracting Linux headers${CLR}"
+   printf "${WHT}Extracting Linux headers${CLR}${NWL}"
 
   rmStep $OBJ_BINUTILS
 
@@ -62,9 +62,8 @@ if [[ ! -d $STEP_DIR ]]; then
     $MAKE ARCH=$ARCH INSTALL_HDR_PATH=$OUT_DIR/$TARGET headers_install || exit 10
   ) || err $?
 
-  echo -e "${GRN}Successfully extracted Linux headers${CLR}"
+  printf "${GRN}Successfully extracted Linux headers${CLR}${NWL}"
 fi
-
 
 #
 # binutils
@@ -74,7 +73,7 @@ SRC_DIR=$DEPS/binutils
 STEP_DIR=$OBJ_BINUTILS
 
 if [[ ! -d $STEP_DIR ]]; then
-  echo -e "${WHT}Compiling binutils${CLR}"
+  printf "${WHT}Compiling binutils${CLR}${NWL}"
 
   rmStep $OBJ_GCC_STATIC
 
@@ -99,7 +98,7 @@ if [[ ! -d $STEP_DIR ]]; then
     $MAKE install || exit 23
   ) || err $?
 
-  echo -e "${GRN}Successfully compiled binutils${CLR}"
+  printf "${GRN}Successfully compiled binutils${CLR}${NWL}"
 fi
 
 
@@ -111,7 +110,7 @@ SRC_DIR=$DEPS/gcc
 STEP_DIR=$OBJ_GCC_STATIC
 
 if [[ ! -d $STEP_DIR ]]; then
-  echo -e "${WHT}Compiling GCC static${CLR}"
+  printf "${WHT}Compiling GCC static${CLR}${NWL}"
 
   rmStep $OBJ_MUSL
 
@@ -160,7 +159,7 @@ if [[ ! -d $STEP_DIR ]]; then
   # [ToDo] Check if we can be able to generate them on different folders
 #  rm -rf $STEP_DIR || exit 35
 
-  echo -e "${GRN}Successfully compiled GCC static${CLR}"
+  printf "${GRN}Successfully compiled GCC static${CLR}${NWL}"
 fi
 
 
@@ -172,7 +171,7 @@ SRC_DIR=$DEPS/musl
 STEP_DIR=$OBJ_MUSL
 
 if [[ ! -d $STEP_DIR ]]; then
-  echo -e "${WHT}Compiling musl${CLR}"
+  printf "${WHT}Compiling musl${CLR}${NWL}"
 
   rmStep $OBJ_GCC_FINAL
 
@@ -198,7 +197,7 @@ if [[ ! -d $STEP_DIR ]]; then
     DESTDIR=$OUT_DIR/$TARGET $MAKE install || exit 43
   ) || err $?
 
-  echo -e "${GRN}Successfully compiled musl${CLR}"
+  printf "${GRN}Successfully compiled musl${CLR}${NWL}"
 fi
 
 
@@ -210,7 +209,7 @@ SRC_DIR=$DEPS/gcc
 STEP_DIR=$OBJ_GCC_FINAL
 
 if [[ ! -d $STEP_DIR ]]; then
-  echo -e "${WHT}Compiling GCC final${CLR}"
+  printf "${WHT}Compiling GCC final${CLR}${NWL}"
 
   (
     mkdir -p $STEP_DIR &&
@@ -247,7 +246,7 @@ if [[ ! -d $STEP_DIR ]]; then
     $MAKE install || exit 53
   ) || err $?
 
-  echo -e "${GRN}Successfully compiled GCC final${CLR}"
+  printf "${GRN}Successfully compiled GCC final${CLR}${NWL}"
 fi
 
 
@@ -263,9 +262,9 @@ rm -rf {,share}/{info,man,doc} || exit 60
 # Strip libraries and binaries
 #
 
-strip --strip-debug    {,$TARGET/}lib/* &>> /dev/null
-strip --strip-unneeded {,$TARGET/}bin/* &>> /dev/null
+strip --strip-debug    {,$TARGET/}lib/* > /dev/null
+strip --strip-unneeded {,$TARGET/}bin/* > /dev/null
 
-strip --strip-unneeded libexec/gcc/$TARGET/*/*{,/*} &>> /dev/null
+strip --strip-unneeded libexec/gcc/$TARGET/*/*{,/*} > /dev/null
 
 exit 0  # Ignore errors from `strip`

--- a/scripts/build
+++ b/scripts/build
@@ -95,7 +95,7 @@ if [[ ! -d $STEP_DIR ]]; then
     $MAKE configure-host && $MAKE || exit 22
 
     # Install
-    $MAKE instal || exit 23
+    $MAKE install || exit 23
   ) || err $?
 
   printf "${GRN}Successfully compiled binutils${CLR}${NWL}"

--- a/scripts/build
+++ b/scripts/build
@@ -57,9 +57,9 @@ if [[ ! -d $STEP_DIR ]]; then
     cd $SRC_DIR
 
     # Extract headers
-    $MAKE mrproper                                                     &&
-    $MAKE ARCH=$ARCH headers_check                                     &&
-    $MAKE ARCH=$ARCH INSTALL_HDR_PATH=$OUT_DIR/$TARGET headers_install || exit 10
+    $MAKE mrproper > /dev/null                                                      &&
+    $MAKE ARCH=$ARCH headers_check > /dev/null                                      &&
+    $MAKE ARCH=$ARCH INSTALL_HDR_PATH=$OUT_DIR/$TARGET headers_install  > /dev/null || exit 10
   ) || err $?
 
   printf "${GRN}Successfully extracted Linux headers${CLR}${NWL}"
@@ -92,10 +92,10 @@ if [[ ! -d $STEP_DIR ]]; then
         --disable-multilib              || exit 21
 
     # Compile
-    $MAKE configure-host && $MAKE || exit 22
+    $MAKE configure-host > /dev/null && $MAKE > /dev/null || exit 22
 
     # Install
-    $MAKE install || exit 23
+    $MAKE install > /dev/null || exit 23
   ) || err $?
 
   printf "${GRN}Successfully compiled binutils${CLR}${NWL}"
@@ -149,10 +149,10 @@ if [[ ! -d $STEP_DIR ]]; then
 #        -mtune=$TUNE                          \
 
     # Compile
-    $MAKE all-gcc all-target-libgcc || exit 33
+    $MAKE all-gcc all-target-libgcc > /dev/null || exit 33
 
     # Install
-    $MAKE install-gcc install-target-libgcc || exit 34
+    $MAKE install-gcc install-target-libgcc > /dev/null || exit 34
   ) || err $?
 
   # Remove object files to allow generation of final version
@@ -191,10 +191,10 @@ if [[ ! -d $STEP_DIR ]]; then
         --disable-static     || exit 41
 
     # Compile
-    CROSS_COMPILE="$TARGET-" $MAKE || exit 42
+    CROSS_COMPILE="$TARGET-" $MAKE > /dev/null || exit 42
 
     # Install
-    DESTDIR=$OUT_DIR/$TARGET $MAKE install || exit 43
+    DESTDIR=$OUT_DIR/$TARGET $MAKE install > /dev/null || exit 43
   ) || err $?
 
   printf "${GRN}Successfully compiled musl${CLR}${NWL}"
@@ -240,10 +240,10 @@ if [[ ! -d $STEP_DIR ]]; then
 #        -mtune=$TUNE                          \
 
     # Compile
-    $MAKE || exit 52
+    $MAKE > /dev/null || exit 52
 
     # Install
-    $MAKE install || exit 53
+    $MAKE install > /dev/null || exit 53
   ) || err $?
 
   printf "${GRN}Successfully compiled GCC final${CLR}${NWL}"

--- a/scripts/prebuild
+++ b/scripts/prebuild
@@ -39,7 +39,7 @@ const GCC_PATCH_URL = 'https://raw.githubusercontent.com/GregorR/musl-cross/mast
 
 
 // Patch Linux to use GLIBC headers
-const LINUX_PATCH_PATH = 'patches/linux-'+LINUX_VERSION+'.diff'
+const LINUX_PATCH_PATH = 'patches/linux/linux-'+LINUX_VERSION+'.diff'
 
 //
 // gcc prerequisites

--- a/scripts/prebuild
+++ b/scripts/prebuild
@@ -39,7 +39,7 @@ const GCC_PATCH_URL = 'https://raw.githubusercontent.com/GregorR/musl-cross/mast
 
 
 // Patch Linux to use GLIBC headers
-const LINUX_PATCH_URL = 'https://raw.githubusercontent.com/joshgarde/nodeos-kernel-headers/master/linux-'+LINUX_VERSION+'.diff'
+const LINUX_PATCH_PATH = 'patches/linux-'+LINUX_VERSION+'.diff'
 
 //
 // gcc prerequisites
@@ -222,7 +222,7 @@ var downloads =
   {
     name: 'linux',
     url: LINUX_URL,
-    patch: LINUX_PATCH_URL,
+    patch: LINUX_PATCH_PATH,
     sha256: LINUX_SHA256
   },
   {

--- a/scripts/prebuild
+++ b/scripts/prebuild
@@ -231,7 +231,7 @@ var downloads =
   }
 ]
 
-if (os.platform() == 'darwin') {
+if (process.platform == 'darwin') {
   downloads.push({
     name: 'glibc-temp',
     url: GLIBC_URL,

--- a/scripts/prebuild
+++ b/scripts/prebuild
@@ -2,8 +2,10 @@
 
 var join = require('path').join
 
+var async   = require('async')
 var fs      = require('fs-extra')
 var manager = require('download-manager')
+var os      = require('os')
 
 
 const DEPS='deps'
@@ -15,6 +17,7 @@ const BINUTILS_VERSION = "2.26"
 const GCC_VERSION      = "5.3.0"
 const LINUX_VERSION    = "4.6"
 const MUSL_VERSION     = "1.1.14"
+const GLIBC_VERSION    = "2.23"
 
 
 // Source URLs
@@ -23,6 +26,7 @@ const BINUTILS_URL = "http://ftpmirror.gnu.org/binutils/binutils-"+BINUTILS_VERS
 const GCC_URL      = "http://ftpmirror.gnu.org/gcc/gcc-"+GCC_VERSION+"/gcc-"+GCC_VERSION+".tar.gz"
 const LINUX_URL    = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-"+LINUX_VERSION+".tar.gz"
 const MUSL_URL     = "http://www.musl-libc.org/releases/musl-"+MUSL_VERSION+".tar.gz"
+const GLIBC_URL    = "http://ftpmirror.gnu.org/glibc/glibc-"+GLIBC_VERSION+".tar.gz"
 
 
 // Checksums
@@ -31,8 +35,11 @@ const LINUX_SHA256 = 'cca08a5bba56d38dd94332f3927d52889231184ba20081f0bf612d3298
 
 
 // Patch GCC to work with musl
-const PATCH_URL = 'https://raw.githubusercontent.com/GregorR/musl-cross/master/patches/gcc-'+GCC_VERSION+'-musl.diff'
+const GCC_PATCH_URL = 'https://raw.githubusercontent.com/GregorR/musl-cross/master/patches/gcc-'+GCC_VERSION+'-musl.diff'
 
+
+// Patch Linux to use GLIBC headers
+const LINUX_PATCH_URL = 'https://raw.githubusercontent.com/joshgarde/nodeos-kernel-headers/master/linux-'+LINUX_VERSION+'.diff'
 
 //
 // gcc prerequisites
@@ -76,23 +83,122 @@ function download_prerequisites(callback)
   ]
 
 
-  manager(downloads, function(error)
-  {
-    if(error) return callback(error)
+  manager(downloads, callback)
+}
 
-    // Check system headers
-    fs.exists('/usr/include/rpc/types.h', function(exists)
-    {
-      if(exists) return callback()
+//
+// include glibc headers in linux
+//
 
-      fs.mkdir('/usr/include/rpc', function(error)
-      {
-        if(error) return callback(error)
+function copy_headers(callback) {
 
-        fs.copy('sunrpc/rpc/*.h', '/usr/include/rpc', callback)
-      })
-    })
-  })
+  const GLIBC_PATH = 'deps/glibc'
+  const TEMP_PATH = 'deps/glibc-temp'
+
+  async.series([
+    function(callback) {
+      async.parallel([
+        function(callback) { fs.mkdirp(GLIBC_PATH+'/bits', callback) },
+        function(callback) { fs.mkdirp(GLIBC_PATH+'/elf', callback) },
+        function(callback) { fs.mkdirp(GLIBC_PATH+'/gnu', callback) },
+        function(callback) { fs.mkdirp(GLIBC_PATH+'/string', callback) }
+      ], callback)
+    },
+    function(callback) {
+      async.parallel([
+        function(callback) {
+          fs.copy(TEMP_PATH+'/elf/elf.h',
+            GLIBC_PATH+'/elf/elf.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/string/byteswap.h',
+            GLIBC_PATH+'/byteswap.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/include/elf.h',
+            GLIBC_PATH+'/elf.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/include/endian.h',
+            GLIBC_PATH+'/endian.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/include/features.h',
+            GLIBC_PATH+'/features.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/include/gnu/stubs.h',
+            GLIBC_PATH+'/gnu/stubs.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/include/stdc-predef.h',
+            GLIBC_PATH+'/stdc-predef.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/string/endian.h',
+            GLIBC_PATH+'/string/endian.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.outputFile(GLIBC_PATH+'/bits/types.h',
+            '',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/bits/typesizes.h',
+            GLIBC_PATH+'/bits/typesizes.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/sysdeps/generic/dl-dtprocnum.h',
+            GLIBC_PATH+'/dl-dtprocnum.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/sysdeps/x86/bits/byteswap-16.h',
+            GLIBC_PATH+'/bits/byteswap-16.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/sysdeps/x86/bits/byteswap.h',
+          GLIBC_PATH+'/bits/byteswap.h',
+          callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/sysdeps/x86/bits/endian.h',
+            GLIBC_PATH+'/bits/endian.h',
+            callback
+          )
+        },
+        function(callback) {
+          fs.copy(TEMP_PATH+'/sysdeps/x86/bits/wordsize.h',
+            GLIBC_PATH+'/bits/wordsize.h',
+            callback
+          )
+        }
+      ], callback)
+    },
+  ], callback)
 }
 
 
@@ -109,13 +215,14 @@ var downloads =
   {
     name: 'gcc',
     url: GCC_URL,
-    patch: PATCH_URL,
+    patch: GCC_PATCH_URL,
     strip: 1,
     action: download_prerequisites
   },
   {
     name: 'linux',
     url: LINUX_URL,
+    patch: LINUX_PATCH_URL,
     sha256: LINUX_SHA256
   },
   {
@@ -124,8 +231,16 @@ var downloads =
   }
 ]
 
+if (os.platform() == 'darwin') {
+  downloads.push({
+    name: 'glibc-temp',
+    url: GLIBC_URL,
+    action: copy_headers
+  })
+}
+
 
 manager(downloads, function(error)
 {
-  if(error) throw error;
+  if(error) throw error
 })


### PR DESCRIPTION
More OS X support -

A few notes about this one:

- In order to get OS X to compile the Linux kernel, various header files needed to be extracted from libc and installed manually to OS X (part of `install-dependencies`)
- Mac OS X, by default, uses a case-insensitive file system, so a virtual file system with case sensitivity was needed to be made with Disk Utility with about 10gb of space. Simple workaround.
- Building still has a few bugs relating to a few missing/incompatible Apple build commands; but `npm install` reports a success when ran.
- Travis support to come soon